### PR TITLE
Not checking for default `dev` option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ module.exports = function(_options) {
     });
 
     // Don't include when run in dev mode
-    if (this.options.dev) {
+    if (options.dev) {
         return;
     }
 


### PR DESCRIPTION
[![JIRA Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fprobot-netsells.node.ns-client.xyz%2Fbadge%2Fpatch-1)](https://netsells.atlassian.net/browse/patch-1)

### Problem statement
Passing in a `dev` option had no effect as it was being pulled from the library defaults (based on `NODE_ENV`)

### Solution
Reading `dev` from the merged `options` instead of `this.options`